### PR TITLE
Adding a concurrent review implementation using goroutines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Jetbrains IDEs
+.idea

--- a/cmd/azqr/main.go
+++ b/cmd/azqr/main.go
@@ -175,7 +175,7 @@ func reviewRunner(rc *ReviewContext, r string, svcAnalysers *[]analyzers.AzureSe
 // Wait for at least "nb" goroutines to hands their result and return them
 func waitForReviews(rc *ReviewContext, nb int) (*[]analyzers.AzureServiceResult, error) {
 	received := 0
-	reviews := make([]analyzers.AzureServiceResult, nb)
+	reviews := make([]analyzers.AzureServiceResult, 0)
 	for {
 		select {
 		// In case a timeout is set

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.1.0
 	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/fbiville/markdown-table-formatter v0.3.0
+	golang.org/x/sync v0.1.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ golang.org/x/crypto v0.0.0-20220511200225-c6db032c6c88 h1:Tgea0cVUD0ivh5ADBX4Wwu
 golang.org/x/crypto v0.0.0-20220511200225-c6db032c6c88/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 h1:HVyaeDAYux4pnY+D/SiwmLOR36ewZ4iGQIIrtnuCjFA=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
# Description

Rewritten the main "review" loop using goroutines. Added a "-p" argument to limit the number of parallel process to use (mainly to prevent 429 with a review of larges resources groups).

## Issue reference

Please reference the issue this PR will close: #26

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly